### PR TITLE
Remove unused isCached variables

### DIFF
--- a/src/core/Shader.js
+++ b/src/core/Shader.js
@@ -92,7 +92,6 @@ GLOW.Shader = (function() {
         
         var data = compiledData.attributeArray;
         var a    = data.length;
-        isCached = cache.attributeCached;
 
         while( a-- ) {
             if( data[ a ].interleaved === false ) {
@@ -104,7 +103,6 @@ GLOW.Shader = (function() {
 
         data     = compiledData.interleavedAttributeArray;
         a        = data.length;
-        isCached = cache.interleavedAttributeCached;
 
         while( a-- ) {
             if( !cache.interleavedAttributeCached( data[ a ] )) {
@@ -114,7 +112,6 @@ GLOW.Shader = (function() {
 
         data     = compiledData.uniformArray;
         a        = data.length;
-        isCached = cache.uniformCached;
 
         while( a-- ) {
             if( !cache.uniformCached( data[ a ] )) {

--- a/src/core/Shader.js
+++ b/src/core/Shader.js
@@ -68,7 +68,6 @@ GLOW.Shader = (function() {
     GLOWShader.prototype.draw = function() {
         var compiledData = this.compiledData;
         var cache = GLOW.currentContext.cache;
-        var isCached = cache.programCached;
 
         if( !cache.programCached( compiledData.program )) {
             GL.useProgram( compiledData.program );


### PR DESCRIPTION
Can't use isCached because reference to cache is needed in cache calls.
No use of isCached.
